### PR TITLE
Add 2 new GitHub snippets

### DIFF
--- a/data/snippets.ts
+++ b/data/snippets.ts
@@ -569,6 +569,16 @@ Fixes #
     keyword: "gh-pr",
     type: "template",
   },
+  {
+    id: nanoid(),
+    name: "Github Table",
+    text: `| Title1 | Title2 |
+| ------- | ------- |
+| Content1 | Content2 |
+  `,
+    keyword: "gh-table",
+    type: "template",
+  },
 ];
 
 const spelling = [

--- a/data/snippets.ts
+++ b/data/snippets.ts
@@ -533,7 +533,7 @@ const project = [
 const github = [
   {
     id: nanoid(),
-    name: "Github Issue Template",
+    name: "GitHub Issue Template",
     text: `## Expected Behavior
 
 ## Actual Behavior
@@ -555,7 +555,7 @@ const github = [
   },
   {
     id: nanoid(),
-    name: "Github Pull Request Template",
+    name: "GitHub Pull Request Template",
     text: `<!-- Thanks for opening a PR! Your contribution is much appreciated.-->
     
 Fixes #
@@ -571,7 +571,7 @@ Fixes #
   },
   {
     id: nanoid(),
-    name: "Github Table",
+    name: "GitHub Table",
     text: `| Title1 | Title2 |
 | ------- | ------- |
 | Content1 | Content2 |
@@ -581,7 +581,7 @@ Fixes #
   },
   {
     id: nanoid(),
-    name: "Github Details",
+    name: "GitHub Details",
     text: `<details>
 <summary>Title</summary>
 {cursor}

--- a/data/snippets.ts
+++ b/data/snippets.ts
@@ -579,6 +579,16 @@ Fixes #
     keyword: "gh-table",
     type: "template",
   },
+  {
+    id: nanoid(),
+    name: "Github Details",
+    text: `<details>
+<summary>Title</summary>
+{cursor}
+</details>`,
+    keyword: "gh-details",
+    type: "template",
+  },
 ];
 
 const spelling = [


### PR DESCRIPTION
I added two new GitHub snippets, and also corrected the capitalization of `GitHub` on the two existing snippets.

The two snippets:

## GitHub Table
Adds the following markdown snippet:

```
| Title1 | Title2 |
| ------- | ------- |
| Content1 | Content2 |
```

Resulting in this:

| Title1 | Title2 |
| ------- | ------- |
| Content1 | Content2 |

## GitHub Details
Adds the following HTML snippet:

```
<details>
 <summary>Title</summary>
{cursor}
</details>
```

Resulting in this:

<details>
 <summary>Title</summary>
Anything you enter where the cursor rests shows here!
</details>