### PR TITLE
Add protocol

### DIFF
--- a/data/snippets.ts
+++ b/data/snippets.ts
@@ -553,6 +553,13 @@ const coding = [
     keyword: "css-ac",
     type: "template",
   },
+  {
+    name: "Protocol",
+    id: nanoid(),
+    text: `https://`,
+    keyword: "www",
+    type: "template",
+  },
 ];
 
 const project = [


### PR DESCRIPTION
When writing in Markdown, you may add a quick link and forget to add the protocol. Type `!www` and get `https//`.