### PR TITLE
Add GitHub Notes and Warning snippets

### DIFF
--- a/data/snippets.ts
+++ b/data/snippets.ts
@@ -669,6 +669,22 @@ Fixes #
     keyword: "gh-details",
     type: "template",
   },
+  {
+    id: nanoid(),
+    name: "GitHub Note",
+    text: `> **Note**
+> {cursor}`,
+    keyword: "gh-note",
+    type: "template",
+  },
+  {
+    id: nanoid(),
+    name: "GitHub Warning",
+    text: `> **Warning**
+> {cursor}`,
+    keyword: "gh-warning",
+    type: "template",
+  },
 ];
 
 const spelling = [


### PR DESCRIPTION
This PR adds two new snippets to the GitHub section:

- `gh-note`: Adds a `note` block:

> **Note**
> Raycast is awesome!

- `gh-warning`: Adds a `warning` block:

> **Warning**
> Raycast is awesome!

I always forget the syntax of these two, hope this helps others like me 🙂 